### PR TITLE
Fix invalid link

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -70,4 +70,4 @@ die Entwickler bei der Umsetzung und versuchen das Projektziel zumindest teilwei
 Wo ist also der Unterschied?
 
 Concept First erlaubt es durchaus, nach einer ersten Konzeptphase den restlichen Weg agil zu gehen. 
-Es erlaubt per se sogar das Prinzip des agilen Fixpreises [(mehr dazu)](/concepts/agiler-fixpreis).
+Es erlaubt per se sogar das Prinzip des agilen Fixpreises [(mehr dazu)](/concepts/agile-fixed-price).


### PR DESCRIPTION
The last link on https://concept-first.org/ links to a non-existent page https://concept-first.org/concepts/agiler-fixpreis which should probably be https://concept-first.org/concepts/agile-fixed-price .